### PR TITLE
Detect only executable files as Python

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-import runpy
-
 import pytest
 
 from venvy import main
-
-
-def test_dunder_main() -> None:
-    with pytest.raises(SystemExit) as exc_info:
-        runpy.run_module("venvy", run_name="__main__")
-    assert exc_info.value.code == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -20,8 +20,8 @@ TESTS_DIR = os.path.dirname(__file__)
         (["bash", "3.7"], ("3.7", ".venv", ["bash"])),
         (["pypy", "myvenv"], ("pypy", "myvenv", [])),
         (
-            [f"{TESTS_DIR}/resources/executable"],
-            (f"{TESTS_DIR}/resources/executable", ".venv", []),
+            [os.path.join(TESTS_DIR, "resources", "executable")],
+            (os.path.join(TESTS_DIR, "resources", "executable"), ".venv", []),
         ),
     ],
 )

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Sequence
 
 import pytest
@@ -7,15 +8,21 @@ import pytest
 from venvy import parse_query
 from venvy import VirtualEnvParams
 
+TESTS_DIR = os.path.dirname(__file__)
 
 # TODO: update derived activators when we detect activators
+
+
 @pytest.mark.parametrize(
     ("query", "expected"), [
         ([], (None, ".venv", [])),
         (["37"], ("37", ".venv", [])),
         (["bash", "3.7"], ("3.7", ".venv", ["bash"])),
         (["pypy", "myvenv"], ("pypy", "myvenv", [])),
-        ([__file__], (__file__, ".venv", [])),
+        (
+            [f"{TESTS_DIR}/resources/executable"],
+            (f"{TESTS_DIR}/resources/executable", ".venv", []),
+        ),
     ],
 )
 def test_parse_query(

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -28,6 +28,10 @@ only_on_nix = pytest.mark.skipif(
         (["37"], ("37", ".venv", [])),
         (["bash", "3.7"], ("3.7", ".venv", ["bash"])),
         (["pypy", "myvenv"], ("pypy", "myvenv", [])),
+        (
+            [os.path.join(TESTS_DIR, "resources", "executable")],
+            (os.path.join(TESTS_DIR, "resources", "executable"), ".venv", []),
+        ),
     ],
 )
 def test_parse_query(
@@ -35,15 +39,3 @@ def test_parse_query(
     expected: tuple[str | None, str, Sequence[str]],
 ) -> None:
     assert parse_query(query) == VirtualEnvParams(*expected)
-
-
-@only_on_nix  # pragma: win32 no cover
-def test_parse_query_on_nix() -> None:
-    exe_path = os.path.join(TESTS_DIR, "resources", "executable")
-    assert parse_query([exe_path]) == (exe_path, ".venv", [])
-
-
-@only_on_win32  # pragma: win32 cover
-def test_parse_query_on_windows() -> None:
-    exe_path = os.path.join(TESTS_DIR, "resources", "executable.bat")
-    assert parse_query([exe_path]) == (exe_path, ".venv", [])

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Sequence
 
 import pytest
@@ -30,3 +31,9 @@ def test_parse_query(
     expected: tuple[str | None, str, Sequence[str]],
 ) -> None:
     assert parse_query(query) == VirtualEnvParams(*expected)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Only runs on Windows")
+def test_parse_query_on_windows() -> None:
+    exe_path = os.path.join(TESTS_DIR, "resources", "executable.bat")
+    assert parse_query([exe_path]) == (exe_path, ".venv", [])

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -14,6 +14,10 @@ only_on_win32 = pytest.mark.skipif(
     sys.platform != "win32",
     reason="Only runs on Windows",
 )
+only_on_nix = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Only runs on non-Windows OS",
+)
 
 # TODO: update derived activators when we detect activators
 
@@ -24,10 +28,6 @@ only_on_win32 = pytest.mark.skipif(
         (["37"], ("37", ".venv", [])),
         (["bash", "3.7"], ("3.7", ".venv", ["bash"])),
         (["pypy", "myvenv"], ("pypy", "myvenv", [])),
-        (
-            [os.path.join(TESTS_DIR, "resources", "executable")],
-            (os.path.join(TESTS_DIR, "resources", "executable"), ".venv", []),
-        ),
     ],
 )
 def test_parse_query(
@@ -35,6 +35,12 @@ def test_parse_query(
     expected: tuple[str | None, str, Sequence[str]],
 ) -> None:
     assert parse_query(query) == VirtualEnvParams(*expected)
+
+
+@only_on_nix  # pragma: win32 no cover
+def test_parse_query_on_nix() -> None:
+    exe_path = os.path.join(TESTS_DIR, "resources", "executable")
+    assert parse_query([exe_path]) == (exe_path, ".venv", [])
 
 
 @only_on_win32  # pragma: win32 cover

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -10,6 +10,10 @@ from venvy import parse_query
 from venvy import VirtualEnvParams
 
 TESTS_DIR = os.path.dirname(__file__)
+only_on_win32 = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Only runs on Windows",
+)
 
 # TODO: update derived activators when we detect activators
 
@@ -33,7 +37,7 @@ def test_parse_query(
     assert parse_query(query) == VirtualEnvParams(*expected)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Only runs on Windows")
+@only_on_win32  # pragma: win32 cover
 def test_parse_query_on_windows() -> None:
     exe_path = os.path.join(TESTS_DIR, "resources", "executable.bat")
     assert parse_query([exe_path]) == (exe_path, ".venv", [])

--- a/tests/resources/executable
+++ b/tests/resources/executable
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "I am a Python executable, I swear!"

--- a/tests/resources/executable.bat
+++ b/tests/resources/executable.bat
@@ -1,1 +1,0 @@
-echo "I am a Python executable, I swear."

--- a/tests/resources/executable.bat
+++ b/tests/resources/executable.bat
@@ -1,0 +1,1 @@
+echo "I am a Python executable, I swear."

--- a/venvy.py
+++ b/venvy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import os.path
 import re
-import stat
 import sys
 from typing import NamedTuple
 from typing import Sequence
@@ -68,8 +67,7 @@ def parse_query(query: list[str]) -> VirtualEnvParams:
             activators.append(activator_map[part])
             continue
 
-        if os.path.exists(part) and os.path.isfile(part) \
-                and stat.S_IXUSR & os.stat(part)[stat.ST_MODE]:
+        if os.path.exists(part) and os.path.isfile(part):
             # probably a python executable?
             python = part
             continue

--- a/venvy.py
+++ b/venvy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os.path
 import re
+import stat
 import sys
 from typing import NamedTuple
 from typing import Sequence
@@ -67,7 +68,8 @@ def parse_query(query: list[str]) -> VirtualEnvParams:
             activators.append(activator_map[part])
             continue
 
-        if os.path.exists(part) and os.path.isfile(part):
+        if os.path.exists(part) and os.path.isfile(part) \
+                and stat.S_IXUSR & os.stat(part)[stat.ST_MODE]:
             # probably a python executable?
             python = part
             continue

--- a/venvy.py
+++ b/venvy.py
@@ -67,7 +67,7 @@ def parse_query(query: list[str]) -> VirtualEnvParams:
             activators.append(activator_map[part])
             continue
 
-        if os.path.exists(part):
+        if os.path.exists(part) and os.path.isfile(part):
             # probably a python executable?
             python = part
             continue


### PR DESCRIPTION
- Fix venvy detecting non-files as Python
- Only detect executable files
- Add tests
