### PR TITLE
Do not support PyPy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy3.9"
         runs-on:
           - "ubuntu"
           - "macos"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Utilities",
     "Typing :: Typed",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{37,38,39,310,311}
-    pypy3
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -11,7 +10,6 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy3.9: pypy3
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
It's unusual that people use PyPy as a system interpreter. Removing PyPy from the supported implementations makes CI runs way faster and support easier.
