### PR TITLE
Actually run the virtualenv

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from venvy import main
+
+CURRENT_PYTHON = f"{sys.version_info[0]}.{sys.version_info[1]}"
 
 
 @pytest.mark.parametrize(
     ("argv", "exit_code"), [
         ([], 0),
-        (["py37"], 0),
+        ([f"python{CURRENT_PYTHON}"], 0),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -11,7 +11,24 @@ from venvy import main
         (["py37"], 0),
     ],
 )
-def test_main_return_value(argv: list[str], exit_code: int) -> None:
+@pytest.mark.parametrize(
+    "shell", [
+        "bash",
+        "xonsh",
+    ],
+)
+def test_main_return_value(
+    argv: list[str],
+    exit_code: int,
+    shell: str,
+    monkeypatch,
+) -> None:
+    import shellingham
+
+    def return_shell():
+        return shell, f"/usr/local/bin/{shell}"
+
+    monkeypatch.setattr(shellingham, "detect_shell", return_shell)
     assert main(argv) == exit_code
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -30,15 +30,3 @@ def test_main_return_value(
 
     monkeypatch.setattr(shellingham, "detect_shell", return_shell)
     assert main(argv) == exit_code
-
-
-@pytest.mark.parametrize(
-    ("argv", "exit_code"), [
-        (["--help"], 0),
-        (["--version"], 0),
-        (["--non-existent-argument"], 2),
-    ],
-)
-def test_argparse(argv: list[str], exit_code: int) -> None:
-    with pytest.raises(SystemExit):
-        assert main(argv) == exit_code

--- a/tests/parse_query_test.py
+++ b/tests/parse_query_test.py
@@ -46,7 +46,7 @@ def test_parse_query(
     import shellingham
 
     def return_bash():
-        return ("bash", "/bin/bash")
+        return "bash", "/bin/bash"
 
     monkeypatch.setattr(shellingham, "detect_shell", return_bash)
     assert parse_query(query) == VirtualEnvParams(*expected)
@@ -56,7 +56,7 @@ def test_parse_query_in_unsupported_shell(monkeypatch) -> None:
     import shellingham
 
     def return_xonsh():
-        return ("xonsh", "/usr/local/bin/xonsh")
+        return "xonsh", "/usr/local/bin/xonsh"
 
     monkeypatch.setattr(shellingham, "detect_shell", return_xonsh)
     assert parse_query([]) == VirtualEnvParams(None, ".venv", set())

--- a/venvy.py
+++ b/venvy.py
@@ -69,7 +69,7 @@ def parse_query(query: list[str]) -> VirtualEnvParams:
             activators.add(activator_map[part])
             continue
 
-        if os.path.exists(part) and os.path.isfile(part):
+        if os.path.isfile(part) and os.access(part, os.X_OK):
             # probably a python executable?
             python = part
             continue

--- a/venvy.py
+++ b/venvy.py
@@ -8,6 +8,7 @@ import sys
 from typing import NamedTuple
 from typing import Sequence
 
+from virtualenv import cli_run
 from virtualenv.run.plugin.base import PluginLoader
 
 if sys.version_info < (3, 8):  # pragma: <3.8 cover
@@ -84,7 +85,11 @@ def parse_query(query: list[str]) -> VirtualEnvParams:
         if current_shell in activator_map:
             activators.add(activator_map[current_shell])
 
-    return VirtualEnvParams(python, dest, activators)
+    return VirtualEnvParams(
+        python=python,
+        dest=dest,
+        activators=activators,
+    )
 
 
 def _get_parser() -> argparse.ArgumentParser:
@@ -113,14 +118,19 @@ def _get_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
-
     args = _get_parser().parse_args(argv)
-    print(args)  # noqa: T201
-
     params = parse_query(args.query)
 
-    from pprint import pprint
-    pprint(params)  # noqa: T203
+    virtualenv_args = [
+        "--download",
+    ]
+    if params.python:
+        virtualenv_args.extend(["--python", params.python])
+    if params.activators:
+        virtualenv_args.extend(["--activators", ",".join(params.activators)])
+    virtualenv_args.append(params.dest)
+
+    cli_run(virtualenv_args)
 
     return 0
 


### PR DESCRIPTION
Runs `virtualenv.cli_run()` after determining its parameters, which in its turn creates the virtual environment.

Closes https://codeberg.org/kytta/venvy/issues/7